### PR TITLE
Revert "NFC: Disable build for AOSP NFC"

### DIFF
--- a/target/product/handheld_system.mk
+++ b/target/product/handheld_system.mk
@@ -54,6 +54,7 @@ PRODUCT_PACKAGES += \
     MmsService \
     MtpService \
     MusicFX \
+    NfcNci \
     PacProcessor \
     PrintRecommendationService \
     PrintSpooler \


### PR DESCRIPTION
This reverts commit 24c48e6085b1f8713bc68478ea76167b6dd93e65.

Reason for revert: AOSP supports the NXP NFC stack

Change-Id: Id4b865662eea012e0f78ef58dff42e4ae055d1ed